### PR TITLE
Clean up usages of "unavailable".

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ The second endpoint is `price`. It allows the user to request the price for a re
     ```
 
 ##### Response Requirements
-- User input can span more than one day, but the API mustn't return a valid price  - it must return `unavailable`
-- User input can span multiple rates, but the API mustn't return a valid price - it must return `unavailable`
+- User input can span more than one day, but the API mustn't return a valid price  - it must return `"unavailable"`
+- User input can span multiple rates, but the API mustn't return a valid price - it must return `"unavailable"`
 - Rates will not span multiple days
 
 ### Application startup


### PR DESCRIPTION
There were two different styles, this makes them all:
`"unavailable"`

instead of:
`unavailable` and `"unavailable"`
